### PR TITLE
feat: add bare metal support

### DIFF
--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -16,3 +16,9 @@ pub use macos::*;
 mod windows;
 #[cfg(target_os = "windows")]
 pub use windows::*;
+
+#[cfg(target_os = "none")]
+mod none;
+
+#[cfg(target_os = "none")]
+pub use none::*;

--- a/src/os/none.rs
+++ b/src/os/none.rs
@@ -1,0 +1,31 @@
+//! Other OS-specific implementations
+
+use crate::{code_manipulate::CodeManipulator, JumpEntry};
+use core::ffi::c_void;
+
+/// Name and attribute of section storing jump entries
+#[doc(hidden)]
+#[macro_export]
+macro_rules! os_static_key_sec_name_attr {
+    () => {
+        "__static_keys, \"awR\""
+    };
+}
+
+extern "Rust" {
+    /// Address of this static is the start address of __static_keys section
+    #[link_name = "__start___static_keys"]
+    pub static mut JUMP_ENTRY_START: JumpEntry;
+    /// Address of this static is the end address of __static_keys section (excluded)
+    #[link_name = "__stop___static_keys"]
+    pub static mut JUMP_ENTRY_STOP: JumpEntry;
+}
+
+/// Arch-specific [`CodeManipulator`] using [`libc`] with `mprotect`.
+pub struct ArchCodeManipulator;
+
+impl CodeManipulator for crate::os::ArchCodeManipulator {
+    unsafe fn write_code<const L: usize>(addr: *mut c_void, data: &[u8; L]) {
+        core::ptr::copy_nonoverlapping(data.as_ptr(), addr.cast(), L);
+    }
+}


### PR DESCRIPTION
I want to use this library on an OS implemented in Rust, which is not Linux/macOS/Windows, and the library lacks support for bare metal OS. Since we cannot know how these bare metal OS modify the code segment, I simply overwrite the memory in the `ArchCodeManipulator::write_code` function. Bare metal OS developers should complete the relevant operations before and after updating the key.