### PR TITLE
Enable Rust 2024 features and add a function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["edition2024"]
 [package]
 name = "static-keys"
 version = "0.6.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,7 @@
-cargo-features = ["edition2024"]
 [package]
 name = "static-keys"
 version = "0.6.2"
-edition = "2024"
+edition = "2021"
 authors = ["Evian-Zhang <evianzhang1999@163.com>"]
 license = "MIT OR Apache-2.0"
 description = "Reimplement Linux kernel static keys for Rust userland applications."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,11 @@ impl<M: CodeManipulator, const S: bool> GenericStaticKey<M, S> {
     pub unsafe fn disable(&self) {
         unsafe { static_key_update(self, false) }
     }
+
+    /// Get the current status of this static key
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(core::sync::atomic::Ordering::Relaxed)
+    }
 }
 
 /// Count of jump entries in __static_keys section. Note that

--- a/src/os/linux.rs
+++ b/src/os/linux.rs
@@ -1,6 +1,6 @@
 //! Linux-specific implementations
 
-use crate::{JumpEntry, code_manipulate::CodeManipulator};
+use crate::{code_manipulate::CodeManipulator, JumpEntry};
 
 // See https://sourceware.org/binutils/docs/as/Section.html
 /// Name and attribute of section storing jump entries

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -1,6 +1,6 @@
 //! macOS-specific implementations
 
-use crate::{JumpEntry, code_manipulate::CodeManipulator};
+use crate::{code_manipulate::CodeManipulator, JumpEntry};
 
 // See https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/Assembler/040-Assembler_Directives/asm_directives.html#//apple_ref/doc/uid/TP30000823-CJBIFBJG
 /// Name and attribute of section storing jump entries

--- a/src/os/none.rs
+++ b/src/os/none.rs
@@ -1,6 +1,6 @@
 //! Other OS-specific implementations
 
-use crate::{JumpEntry, code_manipulate::CodeManipulator};
+use crate::{code_manipulate::CodeManipulator, JumpEntry};
 use core::ffi::c_void;
 
 /// Name and attribute of section storing jump entries

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -2,12 +2,12 @@
 
 use windows::Win32::System::{
     Diagnostics::Debug::FlushInstructionCache,
-    Memory::{PAGE_EXECUTE_READWRITE, PAGE_PROTECTION_FLAGS, VirtualProtect},
+    Memory::{VirtualProtect, PAGE_EXECUTE_READWRITE, PAGE_PROTECTION_FLAGS},
     SystemInformation::{GetSystemInfo, SYSTEM_INFO},
     Threading::GetCurrentProcess,
 };
 
-use crate::{JumpEntry, code_manipulate::CodeManipulator};
+use crate::{code_manipulate::CodeManipulator, JumpEntry};
 
 // Bugs here, DO NOT USE. See https://github.com/rust-lang/rust/issues/128177
 // See https://sourceware.org/binutils/docs/as/Section.html


### PR DESCRIPTION
For lower versions of the rust toolchain, we need to add cargo-features = ["edition2024"]. And I want to get the current state of the key, so I add a function for it.